### PR TITLE
Add realtime traffic website

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,0 +1,36 @@
+import asyncio
+import json
+import time
+
+from fastapi import FastAPI
+from fastapi.responses import HTMLResponse, StreamingResponse
+import psutil
+
+app = FastAPI()
+
+@app.get("/")
+async def index():
+    with open("templates/index.html", "r") as f:
+        html = f.read()
+    return HTMLResponse(html)
+
+async def generate_stats():
+    prev = psutil.net_io_counters()
+    prev_time = time.time()
+    while True:
+        await asyncio.sleep(1)
+        current = psutil.net_io_counters()
+        current_time = time.time()
+        delta_sent = current.bytes_sent - prev.bytes_sent
+        delta_recv = current.bytes_recv - prev.bytes_recv
+        elapsed = current_time - prev_time
+        speed_sent = delta_sent / elapsed
+        speed_recv = delta_recv / elapsed
+        data = json.dumps({"sent": speed_sent, "recv": speed_recv})
+        yield f"data: {data}\n\n"
+        prev = current
+        prev_time = current_time
+
+@app.get("/stats")
+async def stats():
+    return StreamingResponse(generate_stats(), media_type="text/event-stream")

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,6 @@
 # Manually managing azure-functions-worker may cause unexpected issues
 
 azure-functions
+fastapi
+uvicorn
+psutil

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -1,0 +1,5 @@
+body {
+    font-family: Arial, sans-serif;
+    text-align: center;
+    margin-top: 40px;
+}

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -1,0 +1,32 @@
+const ctx = document.getElementById('trafficChart').getContext('2d');
+const chart = new Chart(ctx, {
+    type: 'line',
+    data: {
+        labels: [],
+        datasets: [
+            { label: 'Upload (KB/s)', data: [], borderColor: 'red', fill: false },
+            { label: 'Download (KB/s)', data: [], borderColor: 'blue', fill: false }
+        ]
+    },
+    options: {
+        animation: false,
+        scales: {
+            x: { display: false },
+            y: { beginAtZero: true }
+        }
+    }
+});
+
+const source = new EventSource('/stats');
+source.onmessage = function(event) {
+    const data = JSON.parse(event.data);
+    chart.data.labels.push('');
+    chart.data.datasets[0].data.push((data.sent / 1024).toFixed(2));
+    chart.data.datasets[1].data.push((data.recv / 1024).toFixed(2));
+    if (chart.data.labels.length > 20) {
+        chart.data.labels.shift();
+        chart.data.datasets[0].data.shift();
+        chart.data.datasets[1].data.shift();
+    }
+    chart.update();
+};

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Realtime Internet Traffic</title>
+    <link rel="stylesheet" href="/static/css/style.css">
+    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+</head>
+<body>
+    <h1>Realtime Internet Traffic</h1>
+    <canvas id="trafficChart" width="600" height="300"></canvas>
+    <script src="/static/js/app.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add FastAPI server and SSE endpoint to stream network usage
- show realtime upload/download activity with Chart.js
- include `fastapi`, `uvicorn`, and `psutil` in dependencies

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `uvicorn main:app --port 8000 &` *(manual run)*
- `curl http://127.0.0.1:8000/ | head -n 5`

------
https://chatgpt.com/codex/tasks/task_e_684ae1bd5dbc8320bacada3250826988